### PR TITLE
Reading to amount in power json

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -2,9 +2,9 @@ name: Scala CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,0 +1,22 @@
+name: Scala CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+    - name: Run tests
+      run: sbt test

--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,5 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/sbt,scala,linux,macos,windows,intellij,intellij+all
+
+.bsp/

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ name := "joi-energy-scala"
 
 version := "0.1"
 
-scalaVersion := "2.13.5"
+scalaVersion := "2.13.6"
 
-mainClass in (Compile, run) := Some("com.tw.energy.WebApp")
+Compile / run / mainClass := Some("com.tw.energy.WebApp")
 
 val circeVersion = "0.13.0"
 val akkaVersion = "2.6.14"
@@ -25,4 +25,5 @@ libraryDependencies += "org.scalatest" %% "scalatest" % scalaTestVersion % Test 
 libraryDependencies += "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % Test //utilities to test routes: https://doc.akka.io/docs/akka-http/current/routing-dsl/testkit.html
 libraryDependencies += "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test //required by akka-http-testkit
 libraryDependencies += "org.typelevel"  %% "squants"  % "1.6.0"
+
 scalacOptions ++= Seq("-deprecation", "-feature")

--- a/build.sbt
+++ b/build.sbt
@@ -2,15 +2,15 @@ name := "joi-energy-scala"
 
 version := "0.1"
 
-scalaVersion := "2.13.1"
+scalaVersion := "2.13.5"
 
 mainClass in (Compile, run) := Some("com.tw.energy.WebApp")
 
-val circeVersion = "0.12.3"
-val akkaVersion = "2.6.1"
-val akkaHttpVersion = "10.1.11"
-val akkaHttpCirceVersion = "1.30.0"
-val scalaTestVersion = "3.1.0"
+val circeVersion = "0.13.0"
+val akkaVersion = "2.6.14"
+val akkaHttpVersion = "10.2.4"
+val akkaHttpCirceVersion = "1.36.0"
+val scalaTestVersion = "3.2.9"
 
 libraryDependencies += "com.typesafe.akka" %% "akka-http" % akkaHttpVersion // Http Server library: https://doc.akka.io/docs/akka-http/current/server-side/index.html
 libraryDependencies += "com.typesafe.akka" %% "akka-stream" % akkaVersion // Required by akka-http

--- a/build.sbt
+++ b/build.sbt
@@ -24,5 +24,5 @@ libraryDependencies += "de.heikoseeberger" %% "akka-http-circe" % akkaHttpCirceV
 libraryDependencies += "org.scalatest" %% "scalatest" % scalaTestVersion % Test //Test framework: http://www.scalatest.org/
 libraryDependencies += "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % Test //utilities to test routes: https://doc.akka.io/docs/akka-http/current/routing-dsl/testkit.html
 libraryDependencies += "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test //required by akka-http-testkit
-
+libraryDependencies += "org.typelevel"  %% "squants"  % "1.6.0"
 scalacOptions ++= Seq("-deprecation", "-feature")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.7
+sbt.version = 1.5.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.3")

--- a/src/main/scala/com/tw/energy/Configuration.scala
+++ b/src/main/scala/com/tw/energy/Configuration.scala
@@ -2,6 +2,8 @@ package com.tw.energy
 
 import com.tw.energy.domain.{ElectricityReading, PricePlan}
 import com.tw.energy.generator.Generator
+import squants.energy.KilowattHours
+import squants.market.EUR
 
 object Configuration {
   private val DR_EVILS_DARK_ENERGY_ENERGY_SUPPLIER = "Dr Evil's Dark Energy"
@@ -17,9 +19,9 @@ object Configuration {
   private val ALEXS_SMART_METER_ID = "smart-meter-4"
 
   val pricePlans: List[PricePlan] = List(
-    PricePlan(MOST_EVIL_PRICE_PLAN_ID, DR_EVILS_DARK_ENERGY_ENERGY_SUPPLIER, 10, List()),
-    PricePlan(RENEWABLES_PRICE_PLAN_ID, THE_GREEN_ECO_ENERGY_SUPPLIER, 2, List()),
-    PricePlan(STANDARD_PRICE_PLAN_ID, POWER_FOR_EVERYONE_ENERGY_SUPPLIER, 1, List())
+    PricePlan(MOST_EVIL_PRICE_PLAN_ID, DR_EVILS_DARK_ENERGY_ENERGY_SUPPLIER, EUR(10)/KilowattHours(1), List()),
+    PricePlan(RENEWABLES_PRICE_PLAN_ID, THE_GREEN_ECO_ENERGY_SUPPLIER, EUR(2)/KilowattHours(1), List()),
+    PricePlan(STANDARD_PRICE_PLAN_ID, POWER_FOR_EVERYONE_ENERGY_SUPPLIER, EUR(1)/KilowattHours(1), List())
   )
 
   val smartMeterToPricePlanAccounts: Map[String, String] = Map(

--- a/src/main/scala/com/tw/energy/WebServer.scala
+++ b/src/main/scala/com/tw/energy/WebServer.scala
@@ -14,7 +14,7 @@ class WebServer(val route: Route, val host: String = "localhost", val port: Int 
   implicit val executionContext: ExecutionContext = system.dispatcher
 
   def start(): RunningServer = {
-    new RunningServer(Http().bindAndHandle(route, host, port))
+    new RunningServer(Http().newServerAt(host, port).bindFlow(route))
   }
 
   class RunningServer(bindingFuture: Future[Http.ServerBinding]) {

--- a/src/main/scala/com/tw/energy/controller/JsonSupport.scala
+++ b/src/main/scala/com/tw/energy/controller/JsonSupport.scala
@@ -4,3 +4,5 @@ import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 
 trait JsonSupport extends FailFastCirceSupport {
 }
+
+

--- a/src/main/scala/com/tw/energy/controller/MeterReadingController.scala
+++ b/src/main/scala/com/tw/energy/controller/MeterReadingController.scala
@@ -5,13 +5,13 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives.{complete, get, path, _}
 import akka.http.scaladsl.server.PathMatchers.Segment
 import akka.http.scaladsl.server.Route
-import com.tw.energy.domain.MeterReadings
+import com.tw.energy.domain.{MeterReadings, SquantsJsonSupport}
 import com.tw.energy.domain.StringTypes.SmartMeterId
 import com.tw.energy.service.MeterReadingService
 import io.circe.generic.auto._
 
 
-class MeterReadingController(meterReadingService: MeterReadingService) extends JsonSupport {
+class MeterReadingController(meterReadingService: MeterReadingService) extends JsonSupport with SquantsJsonSupport {
   def routes: Route = pathPrefix("readings") {
     get {
       path("read" / Segment) { smartMeterId =>

--- a/src/main/scala/com/tw/energy/controller/PricePlanComparatorController.scala
+++ b/src/main/scala/com/tw/energy/controller/PricePlanComparatorController.scala
@@ -5,13 +5,13 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives.{complete, get, path, _}
 import akka.http.scaladsl.server.PathMatchers.Segment
 import akka.http.scaladsl.server.Route
-import com.tw.energy.domain.PricePlanCosts
+import com.tw.energy.domain.{PricePlanCosts, SquantsJsonSupport}
 import com.tw.energy.domain.StringTypes.{PlanName, SmartMeterId}
 import com.tw.energy.service.{AccountService, PricePlanService}
 import io.circe.generic.auto._
 
 
-class PricePlanComparatorController(pricePlanService: PricePlanService, accountService: AccountService) extends JsonSupport {
+class PricePlanComparatorController(pricePlanService: PricePlanService, accountService: AccountService) extends JsonSupport with SquantsJsonSupport {
   def routes: Route = pathPrefix("price-plans") {
     get {
       path("compare-all" / Segment) { smartMeterId =>

--- a/src/main/scala/com/tw/energy/domain/ElectricityReading.scala
+++ b/src/main/scala/com/tw/energy/domain/ElectricityReading.scala
@@ -1,29 +1,41 @@
 package com.tw.energy.domain
 
-import io.circe.{Decoder, Encoder, HCursor, Json}
-import io.circe.generic.JsonCodec
+import io.circe._
+import squants.energy.Power
+import squants.market.{Money, MoneyContext, defaultMoneyContext}
 
 import java.time.Instant
-import squants.energy.{Kilowatts, Power}
-import squants.market.Money
 
 case class ElectricityReading(time: Instant, reading: Power)
 
 trait SquantsJsonSupport {
-  implicit val encodePower: Encoder[Power] = (a: Power) => Json.obj(
-    ("reading", Json.fromDouble(a.value).getOrElse(Json.Null)),
-    ("unit", Json.fromString(a.unit.symbol))
+
+  implicit val moneyContext: MoneyContext = defaultMoneyContext
+
+  implicit val encodePower: Encoder[Power] = (power: Power) => Json.obj(
+    ("reading", Json.fromDouble(power.value).getOrElse(Json.Null)),
+    ("unit", Json.fromString(power.unit.symbol))
   )
 
   implicit val decodePower: Decoder[Power] = (c: HCursor) => for {
     reading <- c.downField("reading").as[Double]
     unit <- c.downField("unit").as[String]
+    power <- Power((reading, unit)).fold(ex => Left(DecodingFailure.fromThrowable(ex, c.history)), power => Right(power))
   } yield {
-    Power((reading, unit)).get
+    power
   }
 
-  implicit val encodeMoney: Encoder[Money] = ???
+  implicit val encodeMoney: Encoder[Money] = (money: Money) => Json.obj(
+    ("amount", Json.fromBigDecimal(money.amount)),
+    ("currency", Json.fromString(money.currency.code))
+  )
 
-  implicit val decodeMoney: Decoder[Money] = ???
+  implicit val decodeMoney: Decoder[Money] = (c: HCursor) => for {
+    amount <- c.downField("amount").as[BigDecimal]
+    currency <- c.downField("currency").as[String]
+    money <- Money(amount, currency).fold(ex => Left(DecodingFailure.fromThrowable(ex, c.history)), money => Right(money))
+  } yield {
+    money
+  }
 
 }

--- a/src/main/scala/com/tw/energy/domain/ElectricityReading.scala
+++ b/src/main/scala/com/tw/energy/domain/ElectricityReading.scala
@@ -5,6 +5,7 @@ import io.circe.generic.JsonCodec
 
 import java.time.Instant
 import squants.energy.{Kilowatts, Power}
+import squants.market.Money
 
 case class ElectricityReading(time: Instant, reading: Power)
 
@@ -20,5 +21,9 @@ trait SquantsJsonSupport {
   } yield {
     Power((reading, unit)).get
   }
+
+  implicit val encodeMoney: Encoder[Money] = ???
+
+  implicit val decodeMoney: Decoder[Money] = ???
 
 }

--- a/src/main/scala/com/tw/energy/domain/ElectricityReading.scala
+++ b/src/main/scala/com/tw/energy/domain/ElectricityReading.scala
@@ -13,14 +13,14 @@ trait SquantsJsonSupport {
   implicit val moneyContext: MoneyContext = defaultMoneyContext
 
   implicit val encodePower: Encoder[Power] = (power: Power) => Json.obj(
-    ("reading", Json.fromDouble(power.value).getOrElse(Json.Null)),
+    ("amount", Json.fromDouble(power.value).getOrElse(Json.Null)),
     ("unit", Json.fromString(power.unit.symbol))
   )
 
   implicit val decodePower: Decoder[Power] = (c: HCursor) => for {
-    reading <- c.downField("reading").as[Double]
+    amount <- c.downField("amount").as[Double]
     unit <- c.downField("unit").as[String]
-    power <- Power((reading, unit)).fold(ex => Left(DecodingFailure.fromThrowable(ex, c.history)), power => Right(power))
+    power <- Power((amount, unit)).fold(ex => Left(DecodingFailure.fromThrowable(ex, c.history)), power => Right(power))
   } yield {
     power
   }

--- a/src/main/scala/com/tw/energy/domain/ElectricityReading.scala
+++ b/src/main/scala/com/tw/energy/domain/ElectricityReading.scala
@@ -1,5 +1,6 @@
 package com.tw.energy.domain
 
 import java.time.Instant
+import squants.energy.{Kilowatts, Power}
 
-case class ElectricityReading(time: Instant, reading: BigDecimal)
+case class ElectricityReading(time: Instant, reading: Power)

--- a/src/main/scala/com/tw/energy/domain/ElectricityReading.scala
+++ b/src/main/scala/com/tw/energy/domain/ElectricityReading.scala
@@ -1,6 +1,24 @@
 package com.tw.energy.domain
 
+import io.circe.{Decoder, Encoder, HCursor, Json}
+import io.circe.generic.JsonCodec
+
 import java.time.Instant
 import squants.energy.{Kilowatts, Power}
 
 case class ElectricityReading(time: Instant, reading: Power)
+
+trait SquantsJsonSupport {
+  implicit val encodePower: Encoder[Power] = (a: Power) => Json.obj(
+    ("reading", Json.fromDouble(a.value).getOrElse(Json.Null)),
+    ("unit", Json.fromString(a.unit.symbol))
+  )
+
+  implicit val decodePower: Decoder[Power] = (c: HCursor) => for {
+    reading <- c.downField("reading").as[Double]
+    unit <- c.downField("unit").as[String]
+  } yield {
+    Power((reading, unit)).get
+  }
+
+}

--- a/src/main/scala/com/tw/energy/domain/MeterReadings.scala
+++ b/src/main/scala/com/tw/energy/domain/MeterReadings.scala
@@ -1,5 +1,6 @@
 package com.tw.energy.domain
 
 import com.tw.energy.domain.StringTypes.SmartMeterId
+import io.circe.generic.JsonCodec
 
 case class MeterReadings(smartMeterId: SmartMeterId, electricityReadings: List[ElectricityReading])

--- a/src/main/scala/com/tw/energy/domain/PricePlan.scala
+++ b/src/main/scala/com/tw/energy/domain/PricePlan.scala
@@ -1,11 +1,11 @@
 package com.tw.energy.domain
 
 import java.time.{DayOfWeek, LocalDateTime}
-
 import com.tw.energy.domain.StringTypes.{EnergySupplier, PlanName}
+import squants.{Energy, Price}
 
-case class PricePlan(planName: PlanName, energySupplier: EnergySupplier, unitRate: BigDecimal, peakTimeMultipliers: List[PeakTimeMultiplier] = List()) {
-  def calculatePrice(localDateTime: LocalDateTime): BigDecimal = {
+case class PricePlan(planName: PlanName, energySupplier: EnergySupplier, unitRate: Price[Energy], peakTimeMultipliers: List[PeakTimeMultiplier] = List()) {
+  def calculatePrice(localDateTime: LocalDateTime): Price[Energy] = {
     val multiplier: BigDecimal = peakTimeMultipliers
       .find(_.dayOfWeek == localDateTime.getDayOfWeek)
       .map(_.multiplier)

--- a/src/main/scala/com/tw/energy/domain/PricePlanCosts.scala
+++ b/src/main/scala/com/tw/energy/domain/PricePlanCosts.scala
@@ -1,3 +1,5 @@
 package com.tw.energy.domain
 
-case class PricePlanCosts(pricePlanId: Option[String], pricePlanComparisons: Map[String, BigDecimal])
+import squants.market.Money
+
+case class PricePlanCosts(pricePlanId: Option[String], pricePlanComparisons: Map[String, Money])

--- a/src/main/scala/com/tw/energy/generator/Generator.scala
+++ b/src/main/scala/com/tw/energy/generator/Generator.scala
@@ -1,8 +1,8 @@
 package com.tw.energy.generator
 
 import java.time.Instant
-
 import com.tw.energy.domain.ElectricityReading
+import squants.energy.Kilowatts
 
 import scala.util.Random
 
@@ -14,7 +14,7 @@ object Generator {
                         random: Random = new Random(new java.util.Random())
                       ): List[ElectricityReading] = {
     (0 until number)
-      .map(i => ElectricityReading(time.minusSeconds(deltaSeconds * i), random.nextGaussian().abs))
+      .map(i => ElectricityReading(time.minusSeconds(deltaSeconds * i), Kilowatts(random.nextGaussian().abs)))
       .sortBy(_.time)
       .toList
   }

--- a/src/main/scala/com/tw/energy/service/PricePlanService.scala
+++ b/src/main/scala/com/tw/energy/service/PricePlanService.scala
@@ -3,27 +3,30 @@ package com.tw.energy.service
 
 import com.tw.energy.domain.StringTypes.{PlanName, SmartMeterId}
 import com.tw.energy.domain.{ElectricityReading, PricePlan}
+import squants.energy.{Energy, Kilowatts, Power}
+import squants.market.{EUR, Money}
+import squants.time.{Hours, Time}
 
 class PricePlanService(pricePlans: Seq[PricePlan], meterReadingService: MeterReadingService) {
 
-  private def calculateAverageReading(readings: Seq[ElectricityReading]): BigDecimal = {
-    readings.map(_.reading).sum / readings.length
+  private def calculateAverageReading(readings: Seq[ElectricityReading]): Power = {
+    Kilowatts(readings.map(_.reading.toKilowatts).sum / readings.length)
   }
 
-  private def calculateTimeElapsed(electricityReadings: Seq[ElectricityReading]): BigDecimal = {
+  private def calculateTimeElapsed(electricityReadings: Seq[ElectricityReading]): Time = {
     val first = electricityReadings.minBy(_.time)
     val last = electricityReadings.maxBy(_.time)
-    java.time.Duration.between(first.time, last.time).getSeconds / 3600.0
+    Hours(java.time.Duration.between(first.time, last.time).getSeconds / 3600.0)
   }
 
-  private def calculateCost(readings: Seq[ElectricityReading], plan: PricePlan): BigDecimal = {
-    val average = calculateAverageReading(readings)
-    val timeElapsed = calculateTimeElapsed(readings)
-    val averagedCost = average / timeElapsed
-    (averagedCost * plan.unitRate).setScale(2, BigDecimal.RoundingMode.HALF_UP)
+  private def calculateCost(readings: Seq[ElectricityReading], plan: PricePlan): Money = {
+    val average: Power = calculateAverageReading(readings)
+    val timeElapsed: Time = calculateTimeElapsed(readings)
+    val energyConsumption : Energy = average * timeElapsed
+    EUR(energyConsumption.toKilowattHours * plan.unitRate)
   }
 
-  def consumptionCostByPricePlan(smartMeterId: SmartMeterId): Option[Map[PlanName, BigDecimal]] = {
+  def consumptionCostByPricePlan(smartMeterId: SmartMeterId): Option[Map[PlanName, Money]] = {
     meterReadingService.getReadings(smartMeterId).map { readings =>
       pricePlans.map(plan => plan.planName -> calculateCost(readings, plan)).toMap
     }

--- a/src/main/scala/com/tw/energy/service/PricePlanService.scala
+++ b/src/main/scala/com/tw/energy/service/PricePlanService.scala
@@ -23,7 +23,7 @@ class PricePlanService(pricePlans: Seq[PricePlan], meterReadingService: MeterRea
     val average: Power = calculateAverageReading(readings)
     val timeElapsed: Time = calculateTimeElapsed(readings)
     val energyConsumption : Energy = average * timeElapsed
-    EUR(energyConsumption.toKilowattHours * plan.unitRate)
+    energyConsumption * plan.unitRate
   }
 
   def consumptionCostByPricePlan(smartMeterId: SmartMeterId): Option[Map[PlanName, Money]] = {

--- a/src/test/scala/EndpointIntegrationTest.scala
+++ b/src/test/scala/EndpointIntegrationTest.scala
@@ -2,7 +2,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.stream.ActorMaterializer
-import com.tw.energy.domain.MeterReadings
+import com.tw.energy.domain.{MeterReadings, SquantsJsonSupport}
 import com.tw.energy.generator.Generator
 import com.tw.energy.{JOIEnergyApplication, WebServer}
 import io.circe.generic.auto._
@@ -14,7 +14,7 @@ import org.scalatest.matchers.should.Matchers
 import scala.concurrent.Future
 import scala.util.Random
 
-class EndpointIntegrationTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
+class EndpointIntegrationTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAll with SquantsJsonSupport {
   private implicit val system: ActorSystem = ActorSystem()
   private val application = new JOIEnergyApplication
   private val port = 8000 + Random.nextInt(1000)

--- a/src/test/scala/com/tw/energy/controller/MeterReadingControllerTest.scala
+++ b/src/test/scala/com/tw/energy/controller/MeterReadingControllerTest.scala
@@ -14,7 +14,7 @@ class MeterReadingControllerTest extends AnyFlatSpec with Matchers with Scalates
   val time = "2019-01-24T18:11:27.142Z"
   val reading = Kilowatts(0.6)
   val smartMeterId = "validId"
-  val jsonElectricityReadings = s"""[{"time":"$time","reading":{"reading":0.6,"unit":"kW"}}]"""
+  val jsonElectricityReadings = s"""[{"time":"$time","reading":{"amount":0.6,"unit":"kW"}}]"""
   val jsonMeterReadings = s"""{"smartMeterId":"$smartMeterId","electricityReadings":$jsonElectricityReadings}"""
 
 

--- a/src/test/scala/com/tw/energy/controller/MeterReadingControllerTest.scala
+++ b/src/test/scala/com/tw/energy/controller/MeterReadingControllerTest.scala
@@ -14,7 +14,7 @@ class MeterReadingControllerTest extends AnyFlatSpec with Matchers with Scalates
   val time = "2019-01-24T18:11:27.142Z"
   val reading = Kilowatts(0.6)
   val smartMeterId = "validId"
-  val jsonElectricityReadings = s"""[{"time":"$time","reading":$reading}]"""
+  val jsonElectricityReadings = s"""[{"time":"$time","reading":{"reading":0.6,"unit":"kW"}}]"""
   val jsonMeterReadings = s"""{"smartMeterId":"$smartMeterId","electricityReadings":$jsonElectricityReadings}"""
 
 

--- a/src/test/scala/com/tw/energy/controller/MeterReadingControllerTest.scala
+++ b/src/test/scala/com/tw/energy/controller/MeterReadingControllerTest.scala
@@ -1,7 +1,6 @@
 package com.tw.energy.controller
 
 import java.time.Instant
-
 import akka.http.scaladsl.model.{HttpEntity, MediaTypes, StatusCodes}
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
@@ -9,10 +8,11 @@ import com.tw.energy.domain.ElectricityReading
 import com.tw.energy.service.MeterReadingService
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import squants.energy.Kilowatts
 
 class MeterReadingControllerTest extends AnyFlatSpec with Matchers with ScalatestRouteTest {
   val time = "2019-01-24T18:11:27.142Z"
-  val reading = 0.6
+  val reading = Kilowatts(0.6)
   val smartMeterId = "validId"
   val jsonElectricityReadings = s"""[{"time":"$time","reading":$reading}]"""
   val jsonMeterReadings = s"""{"smartMeterId":"$smartMeterId","electricityReadings":$jsonElectricityReadings}"""

--- a/src/test/scala/com/tw/energy/controller/PricePlanComparatorControllerTest.scala
+++ b/src/test/scala/com/tw/energy/controller/PricePlanComparatorControllerTest.scala
@@ -18,9 +18,9 @@ class PricePlanComparatorControllerTest extends AnyFlatSpec with Matchers with S
   val pricePlan3Id = "second-best-supplier"
   val smartMeterId = "smart-meter-id"
 
-  val pricePlan1 = PricePlan(pricePlan1Id, null, 10, null)
-  val pricePlan2 = PricePlan(pricePlan2Id, null, 1, null)
-  val pricePlan3 = PricePlan(pricePlan3Id, null, 2, null)
+  val pricePlan1 = PricePlan(pricePlan1Id, null, EUR(10)/KilowattHours(1), null)
+  val pricePlan2 = PricePlan(pricePlan2Id, null, EUR(1)/KilowattHours(1), null)
+  val pricePlan3 = PricePlan(pricePlan3Id, null, EUR(2)/KilowattHours(1), null)
 
   trait Setup {
     val meterReadingService = new MeterReadingService()
@@ -36,9 +36,9 @@ class PricePlanComparatorControllerTest extends AnyFlatSpec with Matchers with S
     meterReadingService.storeReadings(MeterReadings(smartMeterId, List(electricityReading, otherReading)))
 
     val expectedPricePlanCost: Map[String, Money] = Map(
-      pricePlan1Id -> EUR(100),
-      pricePlan2Id -> EUR(10),
-      pricePlan3Id -> EUR(20),
+      pricePlan1Id -> EUR(BigDecimal("100.00")),
+      pricePlan2Id -> EUR(BigDecimal("10.00")),
+      pricePlan3Id -> EUR(BigDecimal("20.00")),
     )
 
     val expected = PricePlanCosts(Some(pricePlan1Id), expectedPricePlanCost)
@@ -54,9 +54,9 @@ class PricePlanComparatorControllerTest extends AnyFlatSpec with Matchers with S
     meterReadingService.storeReadings(MeterReadings(smartMeterId, List(electricityReading, otherReading)))
 
     val expectedPricePlanCost: List[Map[String, Money]] = List(
-      Map(pricePlan2Id -> EUR(9.5)),
-      Map(pricePlan3Id -> EUR(19)),
-      Map(pricePlan1Id -> EUR(95))
+      Map(pricePlan2Id -> EUR(BigDecimal("9.50"))),
+      Map(pricePlan3Id -> EUR(BigDecimal("19.00"))),
+      Map(pricePlan1Id -> EUR(BigDecimal("95.00")))
     )
 
     Get(s"/price-plans/recommend/$smartMeterId") ~> controller.routes ~> check {
@@ -71,9 +71,9 @@ class PricePlanComparatorControllerTest extends AnyFlatSpec with Matchers with S
 
     val limit = 2
     val expectedPricePlanCost: List[Map[String, Money]] = List(
-      Map(pricePlan2Id -> EUR(9.375)),
+      Map(pricePlan2Id -> EUR(BigDecimal("9.3750"))),
       //TODO: how to properly handle trailing zeros in decoding/encoding?
-      Map(pricePlan3Id -> EUR(BigDecimal("18.750")))
+      Map(pricePlan3Id -> EUR(BigDecimal("18.7500")))
     )
 
     Get(s"/price-plans/recommend/$smartMeterId?limit=$limit") ~> controller.routes ~> check {
@@ -88,9 +88,9 @@ class PricePlanComparatorControllerTest extends AnyFlatSpec with Matchers with S
 
     val limit = 5
     val expectedPricePlanCost: List[Map[String, Money]] = List(
-      Map(pricePlan2Id -> EUR(14)),
-      Map(pricePlan3Id -> EUR(28)),
-      Map(pricePlan1Id -> EUR(140)),
+      Map(pricePlan2Id -> EUR(BigDecimal("14.00"))),
+      Map(pricePlan3Id -> EUR(BigDecimal("28.00"))),
+      Map(pricePlan1Id -> EUR(BigDecimal("140.00"))),
     )
 
     Get(s"/price-plans/recommend/$smartMeterId?limit=$limit") ~> controller.routes ~> check {

--- a/src/test/scala/com/tw/energy/controller/PricePlanComparatorControllerTest.scala
+++ b/src/test/scala/com/tw/energy/controller/PricePlanComparatorControllerTest.scala
@@ -70,9 +70,9 @@ class PricePlanComparatorControllerTest extends AnyFlatSpec with Matchers with S
     meterReadingService.storeReadings(MeterReadings(smartMeterId, List(electricityReading, otherReading)))
 
     val limit = 2
-    val expectedPricePlanCost: List[Map[String, BigDecimal]] = List(
-      Map(pricePlan2Id -> BigDecimal("16.67")),
-      Map(pricePlan3Id -> BigDecimal("33.33"))
+    val expectedPricePlanCost: List[Map[String, Money]] = List(
+      Map(pricePlan2Id -> EUR(16.67)),
+      Map(pricePlan3Id -> EUR(33.33))
     )
 
     Get(s"/price-plans/recommend/$smartMeterId?limit=$limit") ~> controller.routes ~> check {

--- a/src/test/scala/com/tw/energy/controller/PricePlanComparatorControllerTest.scala
+++ b/src/test/scala/com/tw/energy/controller/PricePlanComparatorControllerTest.scala
@@ -54,9 +54,9 @@ class PricePlanComparatorControllerTest extends AnyFlatSpec with Matchers with S
     meterReadingService.storeReadings(MeterReadings(smartMeterId, List(electricityReading, otherReading)))
 
     val expectedPricePlanCost: List[Map[String, Money]] = List(
-      Map(pricePlan2Id -> EUR(38)),
-      Map(pricePlan3Id -> EUR(76)),
-      Map(pricePlan1Id -> EUR(380))
+      Map(pricePlan2Id -> EUR(9.5)),
+      Map(pricePlan3Id -> EUR(19)),
+      Map(pricePlan1Id -> EUR(95))
     )
 
     Get(s"/price-plans/recommend/$smartMeterId") ~> controller.routes ~> check {
@@ -71,8 +71,9 @@ class PricePlanComparatorControllerTest extends AnyFlatSpec with Matchers with S
 
     val limit = 2
     val expectedPricePlanCost: List[Map[String, Money]] = List(
-      Map(pricePlan2Id -> EUR(16.67)),
-      Map(pricePlan3Id -> EUR(33.33))
+      Map(pricePlan2Id -> EUR(9.375)),
+      //TODO: how to properly handle trailing zeros in decoding/encoding?
+      Map(pricePlan3Id -> EUR(BigDecimal("18.750")))
     )
 
     Get(s"/price-plans/recommend/$smartMeterId?limit=$limit") ~> controller.routes ~> check {

--- a/src/test/scala/com/tw/energy/domain/PricePlanTest.scala
+++ b/src/test/scala/com/tw/energy/domain/PricePlanTest.scala
@@ -1,12 +1,13 @@
 package com.tw.energy.domain
 
 import java.time.{DayOfWeek, LocalDateTime}
-
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import squants.energy.KilowattHours
+import squants.market.EUR
 
 class PricePlanTest extends AnyFlatSpec with Matchers {
-  private val unitRate = 3
+  private val unitRate = EUR(3)/KilowattHours(1)
   private val planName = "plan Name"
   private val supplierName = "Supplier Name"
   private val tuesdayMultiplier = PeakTimeMultiplier(DayOfWeek.TUESDAY, 1.5)
@@ -18,11 +19,11 @@ class PricePlanTest extends AnyFlatSpec with Matchers {
 
 
   "calculatePrice" should "return standard rate when no peak time multiplier applies" in {
-    pricePlan.calculatePrice(monday) should be(3)
+    pricePlan.calculatePrice(monday) should be(EUR(3)/KilowattHours(1))
   }
 
   "calculatePrice" should "return modified rate when multiplier applies" in {
-    pricePlan.calculatePrice(tuesday) should be(4.5)
-    pricePlan.calculatePrice(wednesday) should be(7.5)
+    pricePlan.calculatePrice(tuesday) should be(EUR(4.5)/KilowattHours(1))
+    pricePlan.calculatePrice(wednesday) should be(EUR(7.5)/KilowattHours(1))
   }
 }

--- a/src/test/scala/com/tw/energy/domain/SquantsJsonSupportTest.scala
+++ b/src/test/scala/com/tw/energy/domain/SquantsJsonSupportTest.scala
@@ -61,7 +61,7 @@ class SquantsJsonSupportTest extends AnyFreeSpec with TableDrivenPropertyChecks 
     "should decode instance of power:" - {
       val inputs =
         Table(
-          ("reading", "unit", "result"),
+          ("amount", "unit", "result"),
           (1, "W", Watts(1)),
           (-1, "W", Watts(-1)),
           (100.2, "W", Watts(100.20)),
@@ -72,9 +72,9 @@ class SquantsJsonSupportTest extends AnyFreeSpec with TableDrivenPropertyChecks 
           (1000000.243, "kW", Kilowatts(1000000.243)),
         )
 
-      forAll(inputs) { (reading: Any, unit: String, expected: Power) =>
-        s"should decode $reading $unit" in {
-          val input = s"""{ "reading": $reading, "unit": "$unit" }"""
+      forAll(inputs) { (amount: Any, unit: String, expected: Power) =>
+        s"should decode $amount $unit" in {
+          val input = s"""{ "amount": $amount, "unit": "$unit" }"""
           import org.scalatest.EitherValues._
           decode[Power](input).value shouldBe (expected)
         }
@@ -84,7 +84,7 @@ class SquantsJsonSupportTest extends AnyFreeSpec with TableDrivenPropertyChecks 
     "should encode instance of power:" - {
       val inputs =
         Table(
-          ("power", "reading", "unit"),
+          ("power", "amount", "unit"),
           (Watts(1),"1.0", "W"),
           (Watts(-1) ,"-1.0", "W"),
           (Watts(100.20) ,"100.2", "W"),
@@ -95,11 +95,11 @@ class SquantsJsonSupportTest extends AnyFreeSpec with TableDrivenPropertyChecks 
           (Kilowatts(1000000.243) ,"1000000.243", "kW"),
         )
 
-      forAll(inputs) { (power: Power, reading: String, unit: String) =>
-        s"should encode $reading $unit" in {
+      forAll(inputs) { (power: Power, amount: String, unit: String) =>
+        s"should encode $amount $unit" in {
           val expected =
             s"""{
-               |  "reading" : $reading,
+               |  "amount" : $amount,
                |  "unit" : "$unit"
                |}""".stripMargin
           power.asJson.toString should equal(expected)

--- a/src/test/scala/com/tw/energy/domain/SquantsJsonSupportTest.scala
+++ b/src/test/scala/com/tw/energy/domain/SquantsJsonSupportTest.scala
@@ -5,6 +5,7 @@ import org.scalatest.freespec._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import squants.market.{EUR, Money}
+import io.circe.syntax._
 
 class SquantsJsonSupportTest extends AnyFreeSpec with TableDrivenPropertyChecks with Matchers with SquantsJsonSupport {
 
@@ -18,6 +19,7 @@ class SquantsJsonSupportTest extends AnyFreeSpec with TableDrivenPropertyChecks 
           (100.2, "EUR", EUR(100.20)),
           (100.24, "EUR", EUR(100.24)),
           (100.243, "EUR", EUR(100.243)),
+          (1000000.243, "EUR", EUR(1000000.243)),
           (0.24, "EUR", EUR(0.24)),
         )
 
@@ -29,5 +31,31 @@ class SquantsJsonSupportTest extends AnyFreeSpec with TableDrivenPropertyChecks 
         }
       }
     }
+
+    "should encode instance of money:" - {
+      val inputs =
+        Table(
+          ("money", "amount", "currency"),
+          (EUR(1), "1.0", "EUR"),
+          (EUR(-1), "-1.0", "EUR"),
+          (EUR(100.20), "100.2", "EUR"),
+          (EUR(100.24), "100.24", "EUR"),
+          (EUR(100.243), "100.243", "EUR"),
+          (EUR(1000000.243), "1000000.243", "EUR"),
+          (EUR(0.24), "0.24", "EUR"),
+        )
+
+      forAll(inputs) { (money: Money, amount: String, currency: String) =>
+        s"should encode $amount $currency" in {
+          val expected =
+            s"""{
+               |  "amount" : $amount,
+               |  "currency" : "$currency"
+               |}""".stripMargin
+          money.asJson.toString should equal(expected)
+        }
+      }
+    }
+
   }
 }

--- a/src/test/scala/com/tw/energy/domain/SquantsJsonSupportTest.scala
+++ b/src/test/scala/com/tw/energy/domain/SquantsJsonSupportTest.scala
@@ -1,0 +1,33 @@
+package com.tw.energy.domain
+
+import io.circe.parser.decode
+import org.scalatest.freespec._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import squants.market.{EUR, Money}
+
+class SquantsJsonSupportTest extends AnyFreeSpec with TableDrivenPropertyChecks with Matchers with SquantsJsonSupport {
+
+  "SquantsJsonSupport" - {
+    "should decode instance of money:" - {
+      val inputs =
+        Table(
+          ("amount", "currency", "result"),
+          (1, "EUR", EUR(1)),
+          (-1, "EUR", EUR(-1)),
+          (100.2, "EUR", EUR(100.20)),
+          (100.24, "EUR", EUR(100.24)),
+          (100.243, "EUR", EUR(100.243)),
+          (0.24, "EUR", EUR(0.24)),
+        )
+
+      forAll(inputs) { (amount: Any, currency: String, expected: Money) =>
+        s"should decode $amount $currency" in {
+          val input = s"""{ "amount": $amount, "currency": "$currency" }"""
+          import org.scalatest.EitherValues._
+          decode[Money](input).value shouldBe (expected)
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/com/tw/energy/service/MeterReadingServiceTest.scala
+++ b/src/test/scala/com/tw/energy/service/MeterReadingServiceTest.scala
@@ -1,14 +1,14 @@
 package com.tw.energy.service
 
 import java.time.Instant
-
 import com.tw.energy.domain.{ElectricityReading, MeterReadings}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import squants.energy.Kilowatts
 
 class MeterReadingServiceTest extends AnyFlatSpec with Matchers {
   val meterId = "meterId"
-  val reading = ElectricityReading(Instant.now(), 0.8)
+  val reading = ElectricityReading(Instant.now(), Kilowatts(0.8))
   val readings = List(reading)
 
   "getReadings" should "get readings if Id exists" in {
@@ -34,7 +34,7 @@ class MeterReadingServiceTest extends AnyFlatSpec with Matchers {
 
   "storeReadings" should "append readings if entry already exists" in {
     val service = new MeterReadingService(Map(meterId -> List(reading)))
-    val anotherReading = ElectricityReading(Instant.now(), 0.7)
+    val anotherReading = ElectricityReading(Instant.now(), Kilowatts(0.7))
 
     service.storeReadings(MeterReadings(meterId, List(anotherReading)))
 


### PR DESCRIPTION
Changes the name of the "value" field from "reading" to "amount", in order to decouple from the meter context.