### PR TITLE
[UPGRADE] Upgrading minor-patch versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,18 @@
-name := "joi-energy-scala"
+inThisBuild(
+  List(
+    name := "joi-energy-scala",
+    version := "0.1",
+    scalaVersion := "2.13.10",
+    Compile / mainClass := Some("com.tw.energy.WebApp"),
+    run / mainClass := Some("com.tw.energy.WebApp"),
+  ),
+)
 
-version := "0.1"
-
-scalaVersion := "2.13.1"
-
-mainClass in (Compile, run) := Some("com.tw.energy.WebApp")
-
-val circeVersion = "0.12.3"
-val akkaVersion = "2.6.1"
-val akkaHttpVersion = "10.1.11"
-val akkaHttpCirceVersion = "1.30.0"
-val scalaTestVersion = "3.1.0"
+val circeVersion = "0.14.5"
+val akkaVersion = "2.6.20"
+val akkaHttpVersion = "10.2.10"
+val akkaHttpCirceVersion = "1.39.2"
+val scalaTestVersion = "3.2.15"
 
 libraryDependencies += "com.typesafe.akka" %% "akka-http" % akkaHttpVersion // Http Server library: https://doc.akka.io/docs/akka-http/current/server-side/index.html
 libraryDependencies += "com.typesafe.akka" %% "akka-stream" % akkaVersion // Required by akka-http

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.7
+sbt.version = 1.8.2

--- a/src/main/scala/com/tw/energy/WebServer.scala
+++ b/src/main/scala/com/tw/energy/WebServer.scala
@@ -14,7 +14,7 @@ class WebServer(val route: Route, val host: String = "localhost", val port: Int 
   implicit val executionContext: ExecutionContext = system.dispatcher
 
   def start(): RunningServer = {
-    new RunningServer(Http().bindAndHandle(route, host, port))
+    new RunningServer(Http().newServerAt(host, port).bindFlow(route))
   }
 
   class RunningServer(bindingFuture: Future[Http.ServerBinding]) {

--- a/src/test/scala/EndpointIntegrationTest.scala
+++ b/src/test/scala/EndpointIntegrationTest.scala
@@ -1,7 +1,6 @@
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
-import akka.stream.ActorMaterializer
 import com.tw.energy.domain.MeterReadings
 import com.tw.energy.generator.Generator
 import com.tw.energy.{JOIEnergyApplication, WebServer}


### PR DESCRIPTION
Hi,

I will have a pair programming interview with thoughtworks, and I was checking the repository. It seems that it did not receive a lot of love over the recent years.

Unfortunately, due to the use of Akka HTTP Json, an update to Scala 3 was not possible, but at least I could apply the latest minor version upgrades.

The tests are passing (unfortunately there is no CI here, so you probably have to test it manually).

**Upgrades:**

SBT: 1.3.7 -> 1.8.2
Akka HTTP: 10.1.11 -> 10.2.10
Circe: 0.12.3 -> 0.14.5
Akka HTTP JSON Circe: 1.30.0 -> 1.39.2
Scala Test: 3.1.0 -> 3.2.15

Akka HTTP migration from 10.1.x -> 10.2.x using provided scalafix migration via:

`scalafixAll dependency:MigrateToServerBuilder@com.typesafe.akka:akka-http-scalafix-rules:10.2.0`